### PR TITLE
functionality for outfit page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,7 +18,7 @@ import Login from "./pages/Login";
 import React from "react";
 import Profile from "./pages/Profile";
 import ShowAll from "./pages/closet/ShowAll";
-import ShowAllSelectable from "./pages/outfit/ShowAllSelectable";
+import ShowAllSelectable from "./pages/outfit/CreateOutfitItemSelector";
 import Navbar from "./components/Navbar";
 import CreateOutfit from "./pages/outfit/CreateOutfit";
 
@@ -37,31 +37,6 @@ function App() {
           <Route path="/all-tops" element={<ShowAll type={"tops"} />} />,
           <Route path="/all-bottoms" element={<ShowAll type={"bottoms"} />} />,
           <Route path="/all-footwear" element={<ShowAll type={"footwear"} />} />
-          ,
-          <Route
-            path="/all-accessories"
-            element={<ShowAll type={"accessories"} />}
-          />
-          ,
-          <Route
-            path="/all-selectable-tops"
-            element={<ShowAllSelectable type={"tops"} />}
-          />
-          ,
-          <Route
-            path="/all-selectable-bottoms"
-            element={<ShowAllSelectable type={"bottoms"} />}
-          />
-          ,
-          <Route
-            path="/all-selectable-footwear"
-            element={<ShowAllSelectable type={"footwear"} />}
-          />
-          ,
-          <Route
-            path="/all-selectable-accessories"
-            element={<ShowAllSelectable type={"accessories"} />}
-          />
           ,
           <Route path="*" element={<Home />} />,
         </Routes>

--- a/src/components/ChooseItemsContainer.js
+++ b/src/components/ChooseItemsContainer.js
@@ -5,6 +5,13 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import RemoveCircleIcon from "@mui/icons-material/RemoveCircle";
 
+/**
+ * display container of items in a given category. also allows deletion
+ * @props   type: string of category
+ *          selected: array of items in this category that have been selected
+ *          onClickCategory: function that handles clicking "Choose" button
+ *          onDeleteItem: function that handles deleting an item from outfit
+ */
 function ChooseItemsContainer(props) {
   const [isExpanded, setIsExpanded] = useState(false);
 

--- a/src/components/ChooseItemsContainer.js
+++ b/src/components/ChooseItemsContainer.js
@@ -66,7 +66,7 @@ function ChooseItemsContainer(props) {
 
 function EditItemsCarousel(props) {
   return (
-    <div>
+    <div className="carousel-container">
       {props.selected.map((item, index) => {
         return (
           <EditItem
@@ -84,7 +84,7 @@ function EditItemsCarousel(props) {
 
 function EditItem(props) {
   return (
-    <div>
+    <div className="item-carousel">
       <Box>
         <div
           className="img-container"
@@ -97,6 +97,7 @@ function EditItem(props) {
         aria-label={"Remove item"}
         component="label"
         onClick={props.onDelete}
+        color="error"
       >
         <RemoveCircleIcon />
       </IconButton>

--- a/src/components/ChooseItemsContainer.js
+++ b/src/components/ChooseItemsContainer.js
@@ -18,9 +18,14 @@ function ChooseItemsContainer(props) {
             <h2>{props.title}</h2>
           </Grid>
           <Grid item xs={4}>
-            <Link to={`/all-selectable-${props.title.toLowerCase()}`}>
-              <Button variant="outlined">Choose</Button>
-            </Link>
+            <Button
+              variant="outlined"
+              onClick={() => {
+                props.onClickCategory();
+              }}
+            >
+              Choose
+            </Button>
           </Grid>
         </Grid>
       </div>

--- a/src/components/ChooseItemsContainer.js
+++ b/src/components/ChooseItemsContainer.js
@@ -77,7 +77,7 @@ function EditItemsCarousel(props) {
             onDelete={() => {
               props.onDeleteItem(index);
             }}
-            key={item}
+            key={`edit-items-carousel-${index}`}
           />
         );
       })}
@@ -89,8 +89,11 @@ function EditItem(props) {
   return (
     <div>
       <Box>
-        <div className="img-container" key={props.item}>
-          <img src={props.item} className="img-square" />
+        <div
+          className="img-container"
+          key={`edit-item-container-${props.item["id"]}`}
+        >
+          <img src={props.item["img"]} className="img-square" />
         </div>
       </Box>
       <IconButton

--- a/src/components/ChooseItemsContainer.js
+++ b/src/components/ChooseItemsContainer.js
@@ -1,6 +1,5 @@
 import { Box, Button, Divider, Grid, IconButton } from "@mui/material";
-import React, { Component, useState } from "react";
-import { Link } from "react-router-dom";
+import React, { useState } from "react";
 
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
@@ -15,7 +14,7 @@ function ChooseItemsContainer(props) {
       <div className="container-header">
         <Grid container spacing={2} columns={16}>
           <Grid item xs={12}>
-            <h2>{props.title}</h2>
+            <h2 className="capitalize">{props.type}</h2>
           </Grid>
           <Grid item xs={4}>
             <Button
@@ -37,10 +36,8 @@ function ChooseItemsContainer(props) {
         <div>
           <EditItemsCarousel
             selected={props.selected}
-            // TODO: change
-            onDeleteItem={(index) => {
-              console.log(index);
-            }}
+            onDeleteItem={props.onDeleteItem}
+            type={props.type}
           />
         </div>
       ) : null}
@@ -51,7 +48,7 @@ function ChooseItemsContainer(props) {
           <Grid item>
             <IconButton
               aria-label={`Expand ${isExpanded ? "less" : "more"} to view ${
-                props.title
+                props.type
               }`}
               component="label"
               onClick={() => {
@@ -75,7 +72,7 @@ function EditItemsCarousel(props) {
           <EditItem
             item={item}
             onDelete={() => {
-              props.onDeleteItem(index);
+              props.onDeleteItem(item, props.type);
             }}
             key={`edit-items-carousel-${index}`}
           />

--- a/src/components/DisplayItemsContainer.js
+++ b/src/components/DisplayItemsContainer.js
@@ -95,7 +95,7 @@ function ItemsCarousel(props) {
       {props.items.slice(0, numItems).map((item, index) => {
         return (
           <div
-            className="img-container img-carousel"
+            className="img-container item-carousel"
             key={item["id"]}
             onClick={() => {
               setIndex(index);

--- a/src/index.css
+++ b/src/index.css
@@ -16,6 +16,10 @@ img {
   width: 100%;
 }
 
+h2.capitalize {
+  text-transform: capitalize;
+}
+
 /* use img-container and img-square to make square images! */
 .img-container {
   position: relative;

--- a/src/index.css
+++ b/src/index.css
@@ -49,14 +49,14 @@ h2.capitalize {
   margin-top: 12px;
 }
 
-.img-carousel {
+.item-carousel {
   flex: 0 0 calc(100% / 3);
   justify-content: center;
   align-items: center;
   margin-right: 12px;
 }
 
-.home{
+.home {
     /* 
     height:100%;
     display:flex; 

--- a/src/pages/outfit/CreateOutfit.js
+++ b/src/pages/outfit/CreateOutfit.js
@@ -30,7 +30,7 @@ function CreateOutfit() {
     setShowSelectItem(false);
   };
 
-  // takes in new STATE of items in a category, but just the old ones minus deleted items
+  // takes in new STATE of items in a category, not the deleted ones
   const handleDeleteItems = (newItemsInCategory, type) => {
     items[type] = [...newItemsInCategory];
     setItems({ ...items });

--- a/src/pages/outfit/CreateOutfit.js
+++ b/src/pages/outfit/CreateOutfit.js
@@ -17,6 +17,7 @@ function CreateOutfit() {
     footwear: [],
     accessories: [],
   });
+  const [tags, setTags] = useState([]);
 
   const handleClickCategory = (type) => {
     setChooseCategory(type);
@@ -42,7 +43,9 @@ function CreateOutfit() {
         <CreateOutfitOverview
           onClickCategory={handleClickCategory}
           onDelete={handleDeleteItems}
+          onEditTags={setTags}
           items={items}
+          tags={tags}
         />
       ) : (
         <CreateOutfitItemSelector

--- a/src/pages/outfit/CreateOutfit.js
+++ b/src/pages/outfit/CreateOutfit.js
@@ -1,49 +1,49 @@
 import React, { useState } from "react";
-import { ArrowBackIosNew } from "@mui/icons-material";
-import { Button, Container, Grid } from "@mui/material";
-import ChooseItemsContainer from "../../components/ChooseItemsContainer";
-import { Link } from "react-router-dom";
+import { Container } from "@mui/material";
+import CreateOutfitOverview from "./CreateOutfitOverview";
+import CreateOutfitItemSelector from "./CreateOutfitItemSelector";
 
 function CreateOutfit() {
-  const [top, setTop] = useState([]);
-  const [bottom, setBottom] = useState([]);
-  const [foot, setFoot] = useState([]);
-  const [accessory, setAccessory] = useState([]);
+  // handle switching between the two views
+  const [showSelectItem, setShowSelectItem] = useState(false);
+  const [chooseCategory, setChooseCategory] = useState("");
+
+  // keep track of what items have been selected
+  // make sure keys are the same as the types listed in CreateOutfitItemSelector
+  // and types passed into onClickCategory() in CreateOutfitOverview
+  const [items, setItems] = useState({
+    tops: [],
+    bottoms: [],
+    footwear: [],
+    accessories: [],
+  });
+
+  const handleClickCategory = (type) => {
+    setChooseCategory(type);
+    setShowSelectItem(true);
+  };
+
+  const handleSaveItems = (newItems) => {
+    setItems({ ...newItems });
+    setShowSelectItem(false);
+  };
 
   return (
     <Container>
-      <Grid container>
-        <Grid item>
-          <Link to="/outfit">
-            <Button startIcon={<ArrowBackIosNew />}>Back</Button>
-          </Link>
-        </Grid>
-      </Grid>
-
-      {/* title of page */}
-      <Grid container>
-        <Grid item>
-          <h1>Create Outfit</h1>
-        </Grid>
-      </Grid>
-
-      <Grid container rowSpacing={2}>
-        <Grid item xs={12}>
-          <ChooseItemsContainer title={"Tops"} selected={top} />
-        </Grid>
-
-        <Grid item xs={12}>
-          <ChooseItemsContainer title={"Bottoms"} selected={bottom} />
-        </Grid>
-
-        <Grid item xs={12}>
-          <ChooseItemsContainer title={"Footwear"} selected={foot} />
-        </Grid>
-
-        <Grid item xs={12}>
-          <ChooseItemsContainer title={"Accessories"} selected={accessory} />
-        </Grid>
-      </Grid>
+      {!showSelectItem ? (
+        <CreateOutfitOverview
+          onClickCategory={handleClickCategory}
+          onDelete={setItems}
+          items={items}
+        />
+      ) : (
+        <CreateOutfitItemSelector
+          type={chooseCategory}
+          onBack={() => setShowSelectItem(false)}
+          onSave={handleSaveItems}
+          selected={items[`${chooseCategory}`]}
+        />
+      )}
     </Container>
   );
 }

--- a/src/pages/outfit/CreateOutfit.js
+++ b/src/pages/outfit/CreateOutfit.js
@@ -9,7 +9,7 @@ function CreateOutfit() {
   const [chooseCategory, setChooseCategory] = useState("");
 
   // keep track of what items have been selected
-  // make sure keys are the same as the types listed in CreateOutfitItemSelector
+  // MAKE SURE keys are the same as the types listed in CreateOutfitItemSelector
   // and types passed into onClickCategory() in CreateOutfitOverview
   const [items, setItems] = useState({
     tops: [],
@@ -23,8 +23,9 @@ function CreateOutfit() {
     setShowSelectItem(true);
   };
 
-  const handleSaveItems = (newItems) => {
-    setItems({ ...newItems });
+  const handleSaveItems = (newItemsInCategory, type) => {
+    items[type] = [...newItemsInCategory];
+    setItems({ ...items });
     setShowSelectItem(false);
   };
 

--- a/src/pages/outfit/CreateOutfit.js
+++ b/src/pages/outfit/CreateOutfit.js
@@ -23,10 +23,17 @@ function CreateOutfit() {
     setShowSelectItem(true);
   };
 
+  // takes in new STATE of items in a category, not just the ones being added
   const handleSaveItems = (newItemsInCategory, type) => {
     items[type] = [...newItemsInCategory];
     setItems({ ...items });
     setShowSelectItem(false);
+  };
+
+  // takes in new STATE of items in a category, but just the old ones minus deleted items
+  const handleDeleteItems = (newItemsInCategory, type) => {
+    items[type] = [...newItemsInCategory];
+    setItems({ ...items });
   };
 
   return (
@@ -34,7 +41,7 @@ function CreateOutfit() {
       {!showSelectItem ? (
         <CreateOutfitOverview
           onClickCategory={handleClickCategory}
-          onDelete={setItems}
+          onDelete={handleDeleteItems}
           items={items}
         />
       ) : (

--- a/src/pages/outfit/CreateOutfitItemSelector.js
+++ b/src/pages/outfit/CreateOutfitItemSelector.js
@@ -82,18 +82,8 @@ function CreateOutfitItemSelector(props) {
 
       {/* title of page */}
       <Grid container spacing={2} columns={16}>
-        <Grid item xs={12}>
+        <Grid item>
           <h1>{getTitle(props.type)}</h1>
-        </Grid>
-        <Grid item xs={4}>
-          {JSON.stringify(selected) !== originalSelectedJSON ? (
-            <Button
-              variant="outlined"
-              onClick={() => props.onSave(selected, props.type)}
-            >
-              Confirm
-            </Button>
-          ) : null}
         </Grid>
       </Grid>
 
@@ -111,6 +101,19 @@ function CreateOutfitItemSelector(props) {
       >
         {items()}
       </ToggleButtonGroup>
+
+      {JSON.stringify(selected) !== originalSelectedJSON ? (
+        <Grid container justifyContent={"center"}>
+          <Grid item>
+            <Button
+              variant="outlined"
+              onClick={() => props.onSave(selected, props.type)}
+            >
+              Confirm
+            </Button>
+          </Grid>
+        </Grid>
+      ) : null}
     </>
   );
 }

--- a/src/pages/outfit/CreateOutfitItemSelector.js
+++ b/src/pages/outfit/CreateOutfitItemSelector.js
@@ -82,18 +82,8 @@ function CreateOutfitItemSelector(props) {
 
       {/* title of page */}
       <Grid container spacing={2} columns={16}>
-        <Grid item xs={12}>
+        <Grid item>
           <h1>{getTitle(props.type)}</h1>
-        </Grid>
-        <Grid item xs={4}>
-          {JSON.stringify(selected) !== originalSelectedJSON ? (
-            <Button
-              variant="outlined"
-              onClick={() => props.onSave(selected, props.type)}
-            >
-              Confirm
-            </Button>
-          ) : null}
         </Grid>
       </Grid>
 
@@ -111,6 +101,20 @@ function CreateOutfitItemSelector(props) {
       >
         {items()}
       </ToggleButtonGroup>
+
+      {/* save changes */}
+      {JSON.stringify(selected) !== originalSelectedJSON ? (
+        <Grid container justifyContent={"center"}>
+          <Grid item>
+            <Button
+              variant="outlined"
+              onClick={() => props.onSave(selected, props.type)}
+            >
+              Confirm
+            </Button>
+          </Grid>
+        </Grid>
+      ) : null}
     </>
   );
 }

--- a/src/pages/outfit/CreateOutfitItemSelector.js
+++ b/src/pages/outfit/CreateOutfitItemSelector.js
@@ -7,6 +7,14 @@ import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 
 import { tops, bottoms, footwear, accessories } from "../../data/data.js";
 
+/**
+ * displays a version of the "Show All" page for each category and allows
+ * users to select on items to add to an outfit
+ * @props   selected: array of items for a category that have already been selected
+ *          type: category of this selector (tops, bottoms, etc.)
+ *          onBack: function that handles when clicking on "Back" button
+ *          onSave: function that handles when clicking on "Confirm" button
+ */
 function CreateOutfitItemSelector(props) {
   const [selected, setSelected] = useState([...props.selected]);
   // used to determine whether we display the confirm button

--- a/src/pages/outfit/CreateOutfitItemSelector.js
+++ b/src/pages/outfit/CreateOutfitItemSelector.js
@@ -9,21 +9,22 @@ import { tops, bottoms, footwear, accessories } from "../../data/data.js";
 
 function CreateOutfitItemSelector(props) {
   const [selected, setSelected] = useState([...props.selected]);
+  // used to determine whether we display the confirm button
+  const originalSelectedJSON = JSON.stringify(props.selected);
 
   const handleSelectItem = (item) => {
     let newSelected;
 
     // check if item is already selected
-    if (
-      selected.includes((a) => {
-        return a.id === item.id;
-      })
-    ) {
+    if (selected.some((a) => a.id === item.id)) {
       // deleted selected item!
       newSelected = selected.filter((a) => a.id !== item.id);
     } else {
       // add selected item!
       selected.push(item);
+      selected.sort((a, b) => {
+        return a.id - b.id;
+      });
       newSelected = [...selected];
     }
 
@@ -49,6 +50,7 @@ function CreateOutfitItemSelector(props) {
       default:
         items = [];
     }
+
     return items.map((item, index) => {
       return (
         <ToggleButton
@@ -84,7 +86,7 @@ function CreateOutfitItemSelector(props) {
           <h1>{getTitle(props.type)}</h1>
         </Grid>
         <Grid item xs={4}>
-          {selected.length !== 0 ? (
+          {JSON.stringify(selected) !== originalSelectedJSON ? (
             <Button
               variant="outlined"
               onClick={() => props.onSave(selected, props.type)}

--- a/src/pages/outfit/CreateOutfitItemSelector.js
+++ b/src/pages/outfit/CreateOutfitItemSelector.js
@@ -1,14 +1,14 @@
+import React, { useState } from "react";
+
 import { ArrowBackIosNew } from "@mui/icons-material";
 import { Button, Grid } from "@mui/material";
-import React, { useState } from "react";
-import { Link } from "react-router-dom";
 import ToggleButton from "@mui/material/ToggleButton";
 import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 
 import { tops, bottoms, footwear, accessories } from "../../data/data.js";
 
 function CreateOutfitItemSelector(props) {
-  const [selected, setSelected] = useState([]);
+  const [selected, setSelected] = useState([...props.selected]);
 
   const handleSelectItem = (item) => {
     let newSelected;
@@ -54,7 +54,7 @@ function CreateOutfitItemSelector(props) {
         <ToggleButton
           className="img-container"
           value={index}
-          onClick={() => setSelected(index)}
+          onClick={() => handleSelectItem(item)}
           sx={{ height: "100%", width: "100%" }}
           key={`choose-item-${index}`}
         >
@@ -85,9 +85,12 @@ function CreateOutfitItemSelector(props) {
         </Grid>
         <Grid item xs={4}>
           {selected.length !== 0 ? (
-            <Link to="/create-outfit">
-              <Button variant="outlined">Add</Button>
-            </Link>
+            <Button
+              variant="outlined"
+              onClick={() => props.onSave(selected, props.type)}
+            >
+              Confirm
+            </Button>
           ) : null}
         </Grid>
       </Grid>

--- a/src/pages/outfit/CreateOutfitItemSelector.js
+++ b/src/pages/outfit/CreateOutfitItemSelector.js
@@ -1,5 +1,5 @@
 import { ArrowBackIosNew } from "@mui/icons-material";
-import { Button, Container, Grid } from "@mui/material";
+import { Button, Grid } from "@mui/material";
 import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import ToggleButton from "@mui/material/ToggleButton";
@@ -7,10 +7,29 @@ import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 
 import { tops, bottoms, footwear, accessories } from "../../data/data.js";
 
-function ShowAllSelectable(props) {
-  const [select, setSelected] = useState(-1);
+function CreateOutfitItemSelector(props) {
+  const [selected, setSelected] = useState([]);
 
-  console.log(select);
+  const handleSelectItem = (item) => {
+    let newSelected;
+
+    // check if item is already selected
+    if (
+      selected.includes((a) => {
+        return a.id === item.id;
+      })
+    ) {
+      // deleted selected item!
+      newSelected = selected.filter((a) => a.id !== item.id);
+    } else {
+      // add selected item!
+      selected.push(item);
+      newSelected = [...selected];
+    }
+
+    setSelected(newSelected);
+  };
+
   const items = () => {
     let items;
 
@@ -37,6 +56,7 @@ function ShowAllSelectable(props) {
           value={index}
           onClick={() => setSelected(index)}
           sx={{ height: "100%", width: "100%" }}
+          key={`choose-item-${index}`}
         >
           <img src={item.img} className="img-square" />
         </ToggleButton>
@@ -45,13 +65,16 @@ function ShowAllSelectable(props) {
   };
 
   return (
-    <Container>
+    <>
       {/* back button */}
       <Grid container>
         <Grid item>
-          <Link to="/create-outfit">
-            <Button startIcon={<ArrowBackIosNew />}>Back</Button>
-          </Link>
+          <Button
+            startIcon={<ArrowBackIosNew />}
+            onClick={() => props.onBack()}
+          >
+            Back
+          </Button>
         </Grid>
       </Grid>
 
@@ -61,7 +84,7 @@ function ShowAllSelectable(props) {
           <h1>{getTitle(props.type)}</h1>
         </Grid>
         <Grid item xs={4}>
-          {select != -1 ? (
+          {selected.length !== 0 ? (
             <Link to="/create-outfit">
               <Button variant="outlined">Add</Button>
             </Link>
@@ -71,7 +94,7 @@ function ShowAllSelectable(props) {
 
       {/* all items under category */}
       <ToggleButtonGroup
-        value={select}
+        value={selected}
         exclusive
         sx={{
           display: "grid",
@@ -83,7 +106,7 @@ function ShowAllSelectable(props) {
       >
         {items()}
       </ToggleButtonGroup>
-    </Container>
+    </>
   );
 }
 
@@ -91,4 +114,4 @@ function getTitle(type) {
   return type.charAt(0).toUpperCase() + type.slice(1);
 }
 
-export default ShowAllSelectable;
+export default CreateOutfitItemSelector;

--- a/src/pages/outfit/CreateOutfitItemSelector.js
+++ b/src/pages/outfit/CreateOutfitItemSelector.js
@@ -31,6 +31,10 @@ function CreateOutfitItemSelector(props) {
     setSelected(newSelected);
   };
 
+  const isSelected = (item) => {
+    return selected.some((a) => a.id === item.id);
+  };
+
   const items = () => {
     let items;
 
@@ -57,7 +61,13 @@ function CreateOutfitItemSelector(props) {
           className="img-container"
           value={index}
           onClick={() => handleSelectItem(item)}
-          sx={{ height: "100%", width: "100%" }}
+          sx={{
+            height: "100%",
+            width: "100%",
+            border: `black ${
+              isSelected(item) ? "2px" : "0px"
+            } solid !important`,
+          }}
           key={`choose-item-${index}`}
         >
           <img src={item.img} className="img-square" />

--- a/src/pages/outfit/CreateOutfitOverview.js
+++ b/src/pages/outfit/CreateOutfitOverview.js
@@ -1,0 +1,62 @@
+import React, { Component } from "react";
+import { ArrowBackIosNew } from "@mui/icons-material";
+import { Button, Grid } from "@mui/material";
+import { Link } from "react-router-dom";
+import ChooseItemsContainer from "../../components/ChooseItemsContainer";
+
+// displays the chosen items in all categories
+function CreateOutfitOverview(props) {
+  return (
+    <>
+      <Grid container>
+        <Grid item>
+          <Link to="/outfit">
+            <Button startIcon={<ArrowBackIosNew />}>Back</Button>
+          </Link>
+        </Grid>
+      </Grid>
+
+      {/* title of page */}
+      <Grid container>
+        <Grid item>
+          <h1>Create Outfit</h1>
+        </Grid>
+      </Grid>
+
+      <Grid container rowSpacing={2}>
+        <Grid item xs={12}>
+          <ChooseItemsContainer
+            title={"Tops"}
+            selected={props.items.tops}
+            onClickCategory={() => props.onClickCategory("tops")}
+          />
+        </Grid>
+
+        <Grid item xs={12}>
+          <ChooseItemsContainer
+            title={"Bottoms"}
+            selected={props.items.accessories}
+            onClickCategory={() => props.onClickCategory("bottoms")}
+          />
+        </Grid>
+
+        <Grid item xs={12}>
+          <ChooseItemsContainer
+            title={"Footwear"}
+            selected={props.items.accessories}
+            onClickCategory={() => props.onClickCategory("footwear")}
+          />
+        </Grid>
+
+        <Grid item xs={12}>
+          <ChooseItemsContainer
+            title={"Accessories"}
+            selected={props.items.accessories}
+            onClickCategory={() => props.onClickCategory("accessories")}
+          />
+        </Grid>
+      </Grid>
+    </>
+  );
+}
+export default CreateOutfitOverview;

--- a/src/pages/outfit/CreateOutfitOverview.js
+++ b/src/pages/outfit/CreateOutfitOverview.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React from "react";
 import { ArrowBackIosNew } from "@mui/icons-material";
 import { Button, Grid } from "@mui/material";
 import { Link } from "react-router-dom";
@@ -6,6 +6,12 @@ import ChooseItemsContainer from "../../components/ChooseItemsContainer";
 
 // displays the chosen items in all categories
 function CreateOutfitOverview(props) {
+  const handleDeleteItem = (item, type) => {
+    const oldItems = props.items[type];
+    const newItems = oldItems.filter((a) => a.id !== item.id);
+    props.onDelete(newItems, type);
+  };
+
   return (
     <>
       <Grid container>
@@ -26,33 +32,37 @@ function CreateOutfitOverview(props) {
       <Grid container rowSpacing={2}>
         <Grid item xs={12}>
           <ChooseItemsContainer
-            title={"Tops"}
+            type={"tops"}
             selected={props.items.tops}
             onClickCategory={() => props.onClickCategory("tops")}
+            onDeleteItem={handleDeleteItem}
           />
         </Grid>
 
         <Grid item xs={12}>
           <ChooseItemsContainer
-            title={"Bottoms"}
-            selected={props.items.accessories}
+            type={"bottoms"}
+            selected={props.items.bottoms}
             onClickCategory={() => props.onClickCategory("bottoms")}
+            onDeleteItem={handleDeleteItem}
           />
         </Grid>
 
         <Grid item xs={12}>
           <ChooseItemsContainer
-            title={"Footwear"}
-            selected={props.items.accessories}
+            type={"footwear"}
+            selected={props.items.footwear}
             onClickCategory={() => props.onClickCategory("footwear")}
+            onDeleteItem={handleDeleteItem}
           />
         </Grid>
 
         <Grid item xs={12}>
           <ChooseItemsContainer
-            title={"Accessories"}
+            type={"accessories"}
             selected={props.items.accessories}
             onClickCategory={() => props.onClickCategory("accessories")}
+            onDeleteItem={handleDeleteItem}
           />
         </Grid>
       </Grid>

--- a/src/pages/outfit/CreateOutfitOverview.js
+++ b/src/pages/outfit/CreateOutfitOverview.js
@@ -3,6 +3,7 @@ import { ArrowBackIosNew } from "@mui/icons-material";
 import { Button, Grid } from "@mui/material";
 import { Link, useNavigate } from "react-router-dom";
 import ChooseItemsContainer from "../../components/ChooseItemsContainer";
+import TagsContainer from "../../components/TagsContainer";
 
 /**
  * displays the chosen items in all categories
@@ -18,6 +19,16 @@ function CreateOutfitOverview(props) {
     const oldItems = props.items[type];
     const newItems = oldItems.filter((a) => a.id !== item.id);
     props.onDelete(newItems, type);
+  };
+
+  const handleAddTag = (tag) => {
+    props.tags.push(tag);
+    props.onEditTags([...props.tags]);
+  };
+
+  const handleDeleteTag = (tag) => {
+    const newTags = props.tags.filter((item) => item != tag);
+    props.onEditTags(newTags);
   };
 
   // only display confirm button if there is at least one item added to the outfit
@@ -41,6 +52,18 @@ function CreateOutfitOverview(props) {
       <Grid container>
         <Grid item>
           <h1>Create Outfit</h1>
+        </Grid>
+      </Grid>
+
+      {/* tags section */}
+      <Grid container>
+        <Grid item>
+          <TagsContainer
+            edit={true}
+            tags={props.tags}
+            handleAddTag={handleAddTag}
+            handleDeleteTag={handleDeleteTag}
+          />
         </Grid>
       </Grid>
 

--- a/src/pages/outfit/CreateOutfitOverview.js
+++ b/src/pages/outfit/CreateOutfitOverview.js
@@ -27,7 +27,7 @@ function CreateOutfitOverview(props) {
   };
 
   const handleDeleteTag = (tag) => {
-    const newTags = props.tags.filter((item) => item != tag);
+    const newTags = props.tags.filter((item) => item !== tag);
     props.onEditTags(newTags);
   };
 

--- a/src/pages/outfit/CreateOutfitOverview.js
+++ b/src/pages/outfit/CreateOutfitOverview.js
@@ -6,9 +6,9 @@ import ChooseItemsContainer from "../../components/ChooseItemsContainer";
 
 /**
  * displays the chosen items in all categories
- * @props items: dictionary of all items that belong in the outfit {tops: [], bottoms: [], ...}
- *        onClickCategory: function that handles when user clicks "Choose" button for any category
- *        onDelete: function that handles deleting an item from the outfit
+ * @props   items: dictionary of all items that belong in the outfit {tops: [], bottoms: [], ...}
+ *          onClickCategory: function that handles when user clicks "Choose" button for any category
+ *          onDelete: function that handles deleting an item from the outfit
  */
 function CreateOutfitOverview(props) {
   const navigate = useNavigate();

--- a/src/pages/outfit/CreateOutfitOverview.js
+++ b/src/pages/outfit/CreateOutfitOverview.js
@@ -1,16 +1,31 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { ArrowBackIosNew } from "@mui/icons-material";
 import { Button, Grid } from "@mui/material";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import ChooseItemsContainer from "../../components/ChooseItemsContainer";
 
-// displays the chosen items in all categories
+/**
+ * displays the chosen items in all categories
+ * @props items: dictionary of all items that belong in the outfit {tops: [], bottoms: [], ...}
+ *        onClickCategory: function that handles when user clicks "Choose" button for any category
+ *        onDelete: function that handles deleting an item from the outfit
+ */
 function CreateOutfitOverview(props) {
+  const navigate = useNavigate();
+  const [shouldShowConfirm, setShouldShowConfirm] = useState(false);
+
   const handleDeleteItem = (item, type) => {
     const oldItems = props.items[type];
     const newItems = oldItems.filter((a) => a.id !== item.id);
     props.onDelete(newItems, type);
   };
+
+  // only display confirm button if there is at least one item added to the outfit
+  useEffect(() => {
+    setShouldShowConfirm(
+      Object.keys(props.items).some((key) => props.items[key].length !== 0)
+    );
+  }, [props.items]);
 
   return (
     <>
@@ -66,6 +81,22 @@ function CreateOutfitOverview(props) {
           />
         </Grid>
       </Grid>
+
+      {shouldShowConfirm ? (
+        <Grid container justifyContent={"center"}>
+          <Grid item>
+            {/* TODO: change */}
+            <Button
+              variant="outlined"
+              onClick={() => {
+                navigate("/outfit");
+              }}
+            >
+              Confirm
+            </Button>
+          </Grid>
+        </Grid>
+      ) : null}
     </>
   );
 }


### PR DESCRIPTION
### Changes made
- Renamed `ShowAllSelectable` to be `CreateOutfitItemSelector`.
- The "Show All" page won't be its own routed-to page but will just exist inside of the CreateOutfit page to preserve state changes.
- Can add items for each category using "Show All".
- Can unselect items in each category on "Show All" page.
- Can delete items in the `ChooseItemsContainer`.
- Can add tags to an outfit.

### Screenshots
| <img width="289" alt="Screen Shot 2023-03-31 at 1 27 31 AM" src="https://user-images.githubusercontent.com/40671328/229042318-d711e224-3eab-4478-9514-135e5f62fd31.png"> | <img width="289" alt="Screen Shot 2023-03-31 at 1 35 10 AM" src="https://user-images.githubusercontent.com/40671328/229042320-eb2f3aa8-6f41-4107-84cd-b28b52132c75.png"> | <img width="288" alt="Screen Shot 2023-03-31 at 1 35 21 AM" src="https://user-images.githubusercontent.com/40671328/229042323-9defca90-f43c-4f00-8cc8-88874ecda187.png"> | <img width="289" alt="Screen Shot 2023-03-31 at 1 35 40 AM" src="https://user-images.githubusercontent.com/40671328/229042324-9dd8cad7-27e9-41ab-985e-74990ac03a8d.png"> |
| -- | -- | -- | -- |
| Default state | "Show All" page with items selected | Selected items displayed | Tags added |

### Demo
https://user-images.githubusercontent.com/40671328/229042997-e7195d1b-1269-4a71-a9ec-8cea3751bba2.mov

### Next steps
- discuss how outfit data is being stored in backend -- that may change how the code for this page works & displaying outfit images on other pages
- css
- actually saving data to database

ty to david for the tags container!




