### PR TITLE
CSS to ItemsContainer(s) and changed font

### DIFF
--- a/src/components/AddItemDialog.js
+++ b/src/components/AddItemDialog.js
@@ -20,6 +20,8 @@ import { ref as refStorage } from "firebase/storage";
 import app, { storage } from "../firebase";
 import { uploadBytesResumable, getDownloadURL } from "firebase/storage";
 
+import "../css/Dialog.css";
+
 /**
  * Dialog for adding a new item to the closet.
  * @props       type: string of category of clothing (tops, bottoms, etc.)
@@ -119,7 +121,9 @@ function AddItemDialog(props) {
     <Dialog open={props.open} onClose={handleClose}>
       <DialogTitle>
         <Box display="flex" alignItems="center">
-          <Box flexGrow={1}>Add {props.type}</Box>
+          <Box flexGrow={1}>
+            <h3 className="popup-title">Add {props.type}</h3>
+          </Box>
           <Box>
             <IconButton onClick={handleClose}>
               <CloseIcon />

--- a/src/components/ChooseItemsContainer.js
+++ b/src/components/ChooseItemsContainer.js
@@ -30,6 +30,7 @@ function ChooseItemsContainer(props) {
               onClick={() => {
                 props.onClickCategory();
               }}
+              className={"gray-circle-btn"}
             >
               Choose
             </Button>
@@ -74,7 +75,7 @@ function ChooseItemsContainer(props) {
 
 function EditItemsCarousel(props) {
   if (!props.selected || props.selected.length === 0) {
-    return <div>No {props.type} added.</div>;
+    return <div className="no-items-text">No {props.type} added.</div>;
   }
 
   return (

--- a/src/components/ChooseItemsContainer.js
+++ b/src/components/ChooseItemsContainer.js
@@ -1,5 +1,6 @@
 import { Box, Button, Divider, Grid, IconButton } from "@mui/material";
 import React, { useState } from "react";
+import "../css/ItemsContainer.css";
 
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
@@ -16,10 +17,10 @@ function ChooseItemsContainer(props) {
   const [isExpanded, setIsExpanded] = useState(false);
 
   return (
-    <Box>
+    <Box className="items-container">
       {/* header */}
       <div className="container-header">
-        <Grid container spacing={2} columns={16}>
+        <Grid container spacing={2} columns={16} alignItems={"center"}>
           <Grid item xs={11}>
             <h2 className="capitalize">{props.type}</h2>
           </Grid>
@@ -51,7 +52,7 @@ function ChooseItemsContainer(props) {
 
       {/* handle expanding and minimizing */}
       <div>
-        <Grid container columns={1}>
+        <Grid container columns={1} justifyContent={"center"}>
           <Grid item>
             <IconButton
               aria-label={`Expand ${isExpanded ? "less" : "more"} to view ${

--- a/src/components/DisplayItemsContainer.js
+++ b/src/components/DisplayItemsContainer.js
@@ -3,6 +3,7 @@ import { Box, Button, Divider, Grid, IconButton } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import { Link } from "react-router-dom";
+<<<<<<< HEAD
 import ViewItemDialogContainer from "./ViewItemDialogContainer";
 import AddItemDialog from "./AddItemDialog";
 
@@ -16,6 +17,12 @@ import {
   set,
 } from "firebase/database";
 import { getAuth } from "firebase/auth";
+=======
+import TagsContainer from "./TagsContainer";
+>>>>>>> 2d3d86e (css in progress--push to A8)
+
+import "../css/ItemsContainer.css";
+import { grey } from "@mui/material/colors";
 
 function DisplayItemsContainer(props) {
   const [isExpanded, setIsExpanded] = useState(false);
@@ -136,15 +143,19 @@ function DisplayItemsContainer(props) {
   }, []);
 
   return (
-    <Box>
+    <Box className="items-container">
       {/* header */}
       <div className="container-header">
-        <Grid container spacing={2} columns={16}>
+        <Grid container spacing={2} columns={16} alignItems={"center"}>
           <Grid item xs={12}>
             <h2>{props.title}</h2>
           </Grid>
           <Grid item xs={4} sx={{ textAlign: "end" }}>
-            <Button variant="outlined" onClick={() => setOpen(true)}>
+            <Button
+              variant="outlined"
+              onClick={() => setOpen(true)}
+              className={"gray-circle-btn"}
+            >
               Add
             </Button>
             <AddItemDialog
@@ -171,7 +182,7 @@ function DisplayItemsContainer(props) {
 
       {/* handle expanding and minimizing */}
       <div>
-        <Grid container columns={1}>
+        <Grid container columns={1} justifyContent={"center"}>
           <Grid item>
             <IconButton
               aria-label={`Expand ${isExpanded ? "less" : "more"} to view ${

--- a/src/components/DisplayItemsContainer.js
+++ b/src/components/DisplayItemsContainer.js
@@ -3,7 +3,6 @@ import { Box, Button, Divider, Grid, IconButton } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import { Link } from "react-router-dom";
-<<<<<<< HEAD
 import ViewItemDialogContainer from "./ViewItemDialogContainer";
 import AddItemDialog from "./AddItemDialog";
 
@@ -17,12 +16,8 @@ import {
   set,
 } from "firebase/database";
 import { getAuth } from "firebase/auth";
-=======
-import TagsContainer from "./TagsContainer";
->>>>>>> 2d3d86e (css in progress--push to A8)
 
 import "../css/ItemsContainer.css";
-import { grey } from "@mui/material/colors";
 
 function DisplayItemsContainer(props) {
   const [isExpanded, setIsExpanded] = useState(false);
@@ -210,7 +205,9 @@ function ItemsCarousel(props) {
   const [index, setIndex] = useState(0);
 
   if (!props.items || props.items.length === 0) {
-    return <div>No {props.title.toLowerCase()} found.</div>;
+    return (
+      <div className="no-items-text">No {props.title.toLowerCase()} found.</div>
+    );
   }
 
   const handleDelete = (item) => {
@@ -258,7 +255,8 @@ function ItemsCarousel(props) {
           <Button
             variant="outlined"
             aria-label={`See more ${props.title}`}
-            onClick={null}
+            onClick={() => {}}
+            className={"gray-circle-btn"}
           >
             See more
           </Button>

--- a/src/components/TagsContainer.js
+++ b/src/components/TagsContainer.js
@@ -1,5 +1,12 @@
 import React, { useState } from "react";
-import { Box, Button, IconButton, TextField, Typography, Grid } from "@mui/material";
+import {
+  Box,
+  Button,
+  IconButton,
+  TextField,
+  Typography,
+  Grid,
+} from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
 
 import TagGroup from "./TagGroup";
@@ -17,9 +24,7 @@ function TagsContainer(props) {
   return (
     <Box>
       <Box display="flex" alignItems="center" mb={2}>
-        <Typography variant="body1" style={{ marginRight: "8px" }}>
-          Tags:
-        </Typography>
+        <h4 className="tags-header">Tags</h4>
 
         {props.edit && (
           <Grid container alignItems="center">

--- a/src/components/ViewItemDialogContainer.js
+++ b/src/components/ViewItemDialogContainer.js
@@ -15,6 +15,8 @@ import CloseIcon from "@mui/icons-material/Close";
 import EditIcon from "@mui/icons-material/Edit";
 import TagsContainer from "./TagsContainer";
 
+import "../css/Dialog.css";
+
 /**
  * Dialog for an item's information. Allows them to view and edit.
  * @props       open: boolean that determines whether dialog is displayed
@@ -109,7 +111,9 @@ function EditItemDialog(props) {
     <Dialog {...props}>
       <DialogTitle>
         <Box display="flex" alignItems="center">
-          <Box flexGrow={1}>Edit Item</Box>
+          <Box flexGrow={1}>
+            <h3 className="popup-title">Edit Item</h3>
+          </Box>
           <Box>
             <IconButton onClick={props.handleClose}>
               <CloseIcon />
@@ -185,7 +189,9 @@ function ViewItemDialog(props) {
     <Dialog {...props}>
       <DialogTitle>
         <Box display="flex" alignItems="center">
-          <Box flexGrow={1}>View Item</Box>
+          <Box flexGrow={1}>
+            <h3 className="popup-title">View Item</h3>
+          </Box>
           <Box>
             <IconButton onClick={props.handleEdit}>
               <EditIcon />

--- a/src/components/ViewOutfitDialog.js
+++ b/src/components/ViewOutfitDialog.js
@@ -15,6 +15,8 @@ import CloseIcon from "@mui/icons-material/Close";
 import EditIcon from "@mui/icons-material/Edit";
 import { useNavigate } from "react-router-dom";
 
+import "../css/Dialog.css";
+
 function ViewOutfitDialog(props) {
   const navigate = useNavigate();
 
@@ -34,7 +36,9 @@ function ViewOutfitDialog(props) {
     <Dialog {...props}>
       <DialogTitle>
         <Box display="flex" alignItems="center">
-          <Box flexGrow={1}>View Outfit</Box>
+          <Box flexGrow={1}>
+            <h3 className="popup-title">View Outfit</h3>
+          </Box>
           <Box>
             <IconButton
               onClick={() => {
@@ -74,7 +78,10 @@ function ViewOutfitDialog(props) {
         <Box mt={2}>
           <Grid container>
             <Grid item>
-              <TagsContainer tags={outfit["tags"] || []} handleDeleteTag={() => { }} />
+              <TagsContainer
+                tags={outfit["tags"] || []}
+                handleDeleteTag={() => {}}
+              />
             </Grid>
           </Grid>
         </Box>

--- a/src/css/Dialog.css
+++ b/src/css/Dialog.css
@@ -1,0 +1,11 @@
+.popup-title {
+    margin-top: 0px;
+    margin-bottom: 0px;
+}
+
+.tags-header {
+    margin-top: 0px;
+    margin-bottom: 0px;
+    font-size: 20px;
+    margin-right: 16px;
+}

--- a/src/css/ItemsContainer.css
+++ b/src/css/ItemsContainer.css
@@ -15,3 +15,7 @@
     margin-left: 4px;
     margin-right: 4px;
 }
+
+div.no-items-text {
+    margin-top: 12px;
+}

--- a/src/css/ItemsContainer.css
+++ b/src/css/ItemsContainer.css
@@ -1,0 +1,17 @@
+.items-container {
+    background-color: rgba(255, 178, 148, .3);
+    border-radius: 12px;
+
+    /* formatting */
+    padding: 12px;
+}
+
+.items-container h2 {
+    margin-top: 12px;
+    margin-bottom: 12px;
+}
+
+.container-header {
+    margin-left: 4px;
+    margin-right: 4px;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -76,3 +76,10 @@ h2.capitalize {
 .settings{
   width: auto;
 }
+
+/* button css */
+.gray-circle-btn {
+  color: #757575 !important;
+  border-color: #757575 !important;
+  border-radius: 50% !important;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Besley:ital,wght@0,400;0,500;0,600;0,700;0,800;0,900;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
@@ -10,6 +12,10 @@ body {
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
+}
+
+h1, h2, h3, h4 {
+  font-family: 'Besley', serif;
 }
 
 img {
@@ -66,11 +72,10 @@ h2.capitalize {
     text-align:center;
 }
 
-.name{
-  font-family: 'Besley';
-  font-style: normal;
+.name {
   font-weight: 700;
   font-size: 44px;
+  margin-top: 8px;
 }
 
 .settings{
@@ -81,5 +86,5 @@ h2.capitalize {
 .gray-circle-btn {
   color: #757575 !important;
   border-color: #757575 !important;
-  border-radius: 50% !important;
+  border-radius: 500px !important;
 }

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -72,7 +72,7 @@ function Profile() {
           borderRadius: 1,
         }}
       >
-        <div className="name"> {name} </div>
+        <h1 className={"name"}>{name}</h1>
       </Box>
     </>
   );

--- a/src/pages/outfit/CreateOutfitOverview.js
+++ b/src/pages/outfit/CreateOutfitOverview.js
@@ -124,7 +124,7 @@ function CreateOutfitOverview(props) {
       </Grid>
 
       {shouldShowConfirm ? (
-        <Grid container justifyContent={"center"}>
+        <Grid container justifyContent={"center"} mt={2}>
           <Grid item>
             <Button variant="outlined" onClick={() => props.onSubmit()}>
               Confirm


### PR DESCRIPTION
### Changes made
- Changed `h1`, `h2`, `h3`, `h4` to have Besley font (from Figma)
- Made ItemsContainers orange (from Figma)
- Made ItemsContainer buttons rounded

Note: Tags margin issue on EditOutfit page I think will get fixed by @davidtrak's pr #25 

### Screenshots
|Closet|Create/Edit Outfits|Add/Edit Items Popup|
|--|--|--|
|<img width="289" alt="Screen Shot 2023-04-09 at 11 03 21 PM" src="https://user-images.githubusercontent.com/40671328/230824155-4a3af2e6-47b3-4381-a816-cb30b01beabd.png">|<img width="288" alt="Screen Shot 2023-04-09 at 11 03 57 PM" src="https://user-images.githubusercontent.com/40671328/230824161-08cc98a1-db6a-43e8-b8e3-6a5084b9b3e3.png">|<img width="288" alt="Screen Shot 2023-04-09 at 11 04 29 PM" src="https://user-images.githubusercontent.com/40671328/230824163-977805ea-8fab-4610-a389-62701564fa35.png">|
|<img width="289" alt="Screen Shot 2023-04-09 at 11 03 36 PM" src="https://user-images.githubusercontent.com/40671328/230824158-c0e49bfe-c3e0-4e9f-a89b-9340dcb3b832.png">|<img width="289" alt="Screen Shot 2023-04-09 at 11 04 19 PM" src="https://user-images.githubusercontent.com/40671328/230824162-0f22f94a-6d9a-42d8-ac3c-78f0b9a34937.png">|<img width="288" alt="Screen Shot 2023-04-09 at 11 04 37 PM" src="https://user-images.githubusercontent.com/40671328/230824166-e303c56b-bcce-4b2d-be96-40803ce9010c.png">|